### PR TITLE
Fixed empty rendering bug

### DIFF
--- a/src/app/markdown/markdown.component.ts
+++ b/src/app/markdown/markdown.component.ts
@@ -53,9 +53,8 @@ export class MarkdownComponent implements OnInit, AfterViewInit {
 
         this.mdService.getContent(this.path)
         .then(resp => {
-            if (this.ext !== 'md') {
-                this.md = '```' + this.ext + '\n' + resp.text() + '\n```';
-            }
+            this.md = this.ext !== 'md' ?  '```' + this.ext + '\n' + resp.text() + '\n```' : resp.text();
+
             this.el.nativeElement.innerHTML = marked(this.prepare(this.md));
              Prism.highlightAll(false);
         })


### PR DESCRIPTION
this.md was never set if the extension was 'md' resulting in an empty rendering of the markdown-file