### PR TITLE
correct and add rxjs imports to markdown service

### DIFF
--- a/src/app/markdown/markdown.service.ts
+++ b/src/app/markdown/markdown.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Http } from '@angular/http';
-import 'rxjs/RX';
+import 'rxjs/Rx';
+import 'rxjs/add/operator/toPromise';
 
 @Injectable()
 export class MarkdownService {


### PR DESCRIPTION
Error when using due to incorrect case on Rx and no toPromise import.