### PR TITLE
Fix for Angular dependencies when using Angular-CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,33 +2,32 @@
 Source @ [https://github.com/dimpu/angular2-markdown]()
 
 
-##setup
-
+## Setup
 ```bash
-npm i angular2-markdown   --save
+npm i angular2-markdown --save
 ```
 
-##How to use it
+## How to use it
 ### app.module.js
 ```typescript
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 
-import {MarkdownModule} from 'angular2-markdown';
-import {AppComponent} from '../src/app.component';
+import { MarkdownModule } from 'angular2-markdown';
+import { AppComponent } from '../src/app.component';
 
 @NgModule({
   imports: [
     BrowserModule,
-    MarkdownModule,
+    MarkdownModule.forRoot(),
   ],
   declarations: [AppComponent],
-  bootstrap: [AppComponent]
+  bootstrap: [AppComponent],
 })
 
 ```
 
-app.component.html
+### app.component.html
 ```html
  <div Markdown>
     ### your markdown code
@@ -42,22 +41,18 @@ or use angular component
 
 // to load from remote url
 
- <div Markdown path="/path/to/readme.md"> </div>
+<div Markdown path="/path/to/readme.md"></div>
 
 // load remote source code with auto syantax helight.
 
-
 <markdown path="/path/to/code.cpp"></markdown>
 
-
 <markdown path="/path/to/code.java"></markdown>
-
-
 ```
 
-## example
+## Example
 
-You can found the working example inside the src/app/demo directory.
+You can found the working example inside the `src/app/demo directory`.
 
 ```
 git clone https://github.com/dimpu/angular2-markdown.git
@@ -67,5 +62,3 @@ npm i
 ng serve
 ```
 now you should see working example at [http://localhost:4200]()
-
-

--- a/src/app/markdown/markdown.module.ts
+++ b/src/app/markdown/markdown.module.ts
@@ -1,4 +1,4 @@
-import { NgModule } from '@angular/core';
+import { ModuleWithProviders, NgModule } from '@angular/core';
 import { HttpModule } from '@angular/http';
 import { MarkdownComponent } from './markdown.component';
 import { MarkdownService } from './markdown.service';
@@ -9,4 +9,10 @@ import { MarkdownService } from './markdown.service';
   declarations: [MarkdownComponent],
   providers: [MarkdownService],
 })
-export class MarkdownModule { }
+export class MarkdownModule {
+  static forRoot(): ModuleWithProviders {
+    return {
+      ngModule: MarkdownModule,
+    };
+  }
+}


### PR DESCRIPTION
Workaround as explained [here](https://github.com/angular/angular-cli/issues/3854#issuecomment-274344771) to fix Angular package dependencies.

Using Angular-CLI we currently get the following error:
`Error encountered resolving symbol values statically. Calling function 'makeDecorator', function calls are not supported.`

Adding `forRoot()` to `markdown.module` solves the problem. It is considered a 'workaround' with Angular-CLI because it does not come with TypeScript 2.1 for now.