### PR TITLE
Removes console.log from ngOnInit

### DIFF
--- a/src/app/markdown/markdown.component.ts
+++ b/src/app/markdown/markdown.component.ts
@@ -35,10 +35,7 @@ export class MarkdownComponent implements OnInit, AfterViewInit {
         private http: Http
     ) { }
 
-    ngOnInit() {
-        console.log(this.path);
-        console.log('The component is initialized');
-    }
+    ngOnInit() {}
 
     /**
      * on path input change


### PR DESCRIPTION
In my opinion having the ngOnInit log to the console just creates
noise and I think it's unnecessary, this PR addresses that.