### PR TITLE
Gracefully handle case where data input to MarkdownComponent is undefined.

### DIFF
--- a/src/markdown/markdown.component.ts
+++ b/src/markdown/markdown.component.ts
@@ -44,7 +44,11 @@ export class MarkdownComponent implements OnInit {
 
     // on input
     onDataChange(data:string){
-      this.el.nativeElement.innerHTML = this.mdService.compile(data);
+      if (data) {
+        this.el.nativeElement.innerHTML = this.mdService.compile(data);
+      } else {
+        this.el.nativeElement.innerHTML = '';
+      }
       Prism.highlightAll(false);
     }
 


### PR DESCRIPTION
I am using the component by passing the data into the component like this:

`<markdown [data]="{{ mdText }}"></markdown>`

The text in my app is often loaded dynamically and the initial value is undefined. Instead of changing all the places the component is used to guard against the undefined it would be much nicer if the component handled the case.