### PR TITLE
Fixed marked.js import

### DIFF
--- a/src/markdown/markdown.service.ts
+++ b/src/markdown/markdown.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Http, Response} from '@angular/http';
 import { Observable } from 'rxjs/Observable';
-import * as  marked from 'marked';
+import marked from 'marked';
 
 import 'rxjs/add/observable/throw';
 import 'rxjs/add/operator/catch';

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -4,6 +4,7 @@
     "target": "es5",
     "module": "es2015",
     "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "sourceMap": true,


### PR DESCRIPTION
Current import of marked.js causes problems using es modules. See #78 