### PR TITLE
Cope with sanitized ng-content

### DIFF
--- a/demo/src/app/home/home.component.html
+++ b/demo/src/app/home/home.component.html
@@ -15,6 +15,23 @@
                     </form>
                 </div>
             </div>
+            <!-- to see how code changes here affected ng-content cases
+            <div class="panel panel-default">
+                <div class="panel-heading">
+                    <h3 class="panel-title">HTML from Markdown ng-content 1</h3>
+                </div>
+                <div class="panel-body">
+                    <markdown>{{ngContent1}}</markdown>
+                </div>
+
+                <div class="panel-heading">
+                    <h3 class="panel-title">HTML from Markdown ng-content 2</h3>
+                </div>
+                <div class="panel-body">
+                    <markdown>{{ngContent2}}</markdown>
+                </div>
+            </div>
+            -->
         </div>
         <div class="col-xs-6 col-sm-6 col-md-6 col-lg-6">
             <div class="panel panel-default">

--- a/demo/src/app/home/home.component.ts
+++ b/demo/src/app/home/home.component.ts
@@ -108,6 +108,19 @@ import * as extras from 'marked-extras';
   `]
 })
 export class HomeComponent implements OnInit {
+  /*
+  ngContent1:string = [
+    "```javascript",
+    "setTimeout(_ => alert('Hello'));",
+    "```",
+   ].join("\n");  
+  ngContent2:string = [
+    "```html",
+    "<div>Hello html</div>",
+    "```",
+   ].join("\n");  
+  */
+  
   public markdownContent: string = `
 # Headers
 

--- a/src/markdown/mardown.component.spec.ts
+++ b/src/markdown/mardown.component.spec.ts
@@ -7,6 +7,9 @@ import 'rxjs/add/observable/of';
 import 'rxjs/add/operator/toPromise';
 import * as marked from 'marked';
 
+import { Component, DebugElement } from '@angular/core';
+import { By } from '@angular/platform-browser';
+
 class MockMarkdownService extends MarkdownService {
   getContent(src: string): Observable<any> {
     return Observable.of('');
@@ -45,7 +48,7 @@ describe('MarkdownComponent', () => {
       expect(component.onPathChange).toHaveBeenCalled();
     });
 
-    it('should call handleRaw method when src is not provided', () => {
+    it('should call `processRaw` method when [data] is not provided', () => {
       spyOn(component, 'processRaw');
       const mockElement = { nativeElement: { innerHTML: 'html-inner' } };
       component.element = mockElement;
@@ -55,7 +58,7 @@ describe('MarkdownComponent', () => {
       expect(component.processRaw).toHaveBeenCalled();
     });
 
-    it('should not call handleRaw method when data is provided', () => {
+    it('should not call `processRaw` method when [data] is provided', () => {
       spyOn(component, 'processRaw');
       component.path = undefined;
       component.data = 'some markdown';
@@ -65,7 +68,45 @@ describe('MarkdownComponent', () => {
     });
   });
 
+});
 
-  
+@Component({ selector: 'host-for-test', template: '' })
+class HostComponent {
+}
+
+function createHostComponent(template : string) : ComponentFixture<HostComponent> {
+  TestBed.overrideTemplate(HostComponent, template);
+  const fixture = TestBed.createComponent(HostComponent);
+  fixture.detectChanges();
+  return fixture as ComponentFixture<HostComponent>;
+}
+
+describe('MarkdownComponent in host', () => {
+  let fixture: ComponentFixture<HostComponent>;
+  let component: HostComponent;
+
+  const ngContent1 = 'html-inner';
+  const ngContent2 = '```html\n<div>Hi</div>\n```';
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpModule],
+      declarations: [MarkdownComponent, HostComponent],
+      providers: [
+        { provide: MarkdownService, useClass: MockMarkdownService },
+      ],
+    });
+  });
+
+  describe('when using ng-content', () => {
+    it('should pass the transcluded content unchanged', () => {
+      const template = `<markdown>${ngContent2}</markdown>`;
+      fixture = createHostComponent(template);
+      const debugElement = fixture.debugElement.query(By.directive(MarkdownComponent)) as DebugElement;
+      const component = debugElement.componentInstance;
+
+      expect(component._md).toBe(ngContent2);
+    });
+  });
 
 });

--- a/src/markdown/markdown.component.ts
+++ b/src/markdown/markdown.component.ts
@@ -68,7 +68,7 @@ export class MarkdownComponent implements OnInit {
     }
 
     processRaw() {
-      this._md = this.prepare(this.el.nativeElement.innerHTML);
+      this._md = this.prepare(decodeHtml(this.el.nativeElement.innerHTML));
       this.el.nativeElement.innerHTML = this.mdService.compile(this._md);
       Prism.highlightAll(false);
     }
@@ -120,4 +120,10 @@ export class MarkdownComponent implements OnInit {
     private trimLeft(line: string) {
         return line.replace(/^\s+|\s+$/g, '');
     }
+}
+
+function decodeHtml(html:string) { // https://stackoverflow.com/a/7394787/588521
+    var txt = document.createElement("textarea");
+    txt.innerHTML = html;
+    return txt.value;
 }


### PR DESCRIPTION
In ng-content use cases, some contents are escaped by sanitizer so end
result looks broken. Code changes here make sure original content to be
passed to marked. Related to issue #73.