### PR TITLE
Fix flattened nested list

### DIFF
--- a/src/markdown/markdown.component.ts
+++ b/src/markdown/markdown.component.ts
@@ -98,20 +98,8 @@ export class MarkdownComponent implements OnInit {
     /**
      * Prepare string
      */
-     prepare(raw: string) {
-        if (!raw) {
-            return '';
-        }
-        if (this._ext === 'md' || !this.path) {
-            let isCodeBlock = false;
-            return raw.split('\n').map((line: string) => {
-                if (this.trimLeft(line).substring(0, 3) === "```") {
-                    isCodeBlock = !isCodeBlock;
-                }
-                return isCodeBlock ? line : line.trim();
-            }).join('\n');
-        }
-        return raw.replace(/\"/g, '\'');
+    prepare(raw: string) {
+        return raw || '';
     }
 
     /**


### PR DESCRIPTION
In MarkdownComponent, prepare() function seems to be doing its job ok for code block but with unwanted side effect of flattened nested list as it is removing any indentations for list. It would be better to let 'marked' do the job. Related to issues #41, #38.