### PR TITLE
fix(markdown.component): check for isPlatformBrowser before calling Prism.highlightAll

### DIFF
--- a/src/markdown/markdown.component.ts
+++ b/src/markdown/markdown.component.ts
@@ -1,7 +1,8 @@
-import { Component, ElementRef, OnInit, AfterViewInit, Input } from '@angular/core';
+import { Component, ElementRef, OnInit, AfterViewInit, Input, PLATFORM_ID, Inject } from '@angular/core';
 import { Http } from '@angular/http';
 import { MarkdownService } from './markdown.service';
 import './prism.languages';
+import { isPlatformBrowser } from '@angular/common';
 
 @Component({
     selector: 'markdown,[Markdown]',
@@ -22,7 +23,8 @@ export class MarkdownComponent implements OnInit {
     constructor(
         private mdService: MarkdownService,
         private el: ElementRef,
-        private http: Http
+        private http: Http,
+        @Inject(PLATFORM_ID) private platformId: string
     ) { }
 
     ngOnInit() {
@@ -53,7 +55,7 @@ export class MarkdownComponent implements OnInit {
       } else {
         this.el.nativeElement.innerHTML = '';
       }
-      Prism.highlightAll(false);
+      this.highlightContent(false);
     }
 
     /**
@@ -70,7 +72,7 @@ export class MarkdownComponent implements OnInit {
     processRaw() {
       this._md = this.prepare(this.el.nativeElement.innerHTML);
       this.el.nativeElement.innerHTML = this.mdService.compile(this._md);
-      Prism.highlightAll(false);
+      this.highlightContent(false);
     }
 
     /**
@@ -82,7 +84,7 @@ export class MarkdownComponent implements OnInit {
             .subscribe(data => {
                 this._md = this._ext !== 'md' ? '```' + this._ext + '\n' + data + '\n```' : data;
                 this.el.nativeElement.innerHTML = this.mdService.compile(this.prepare(this._md));
-                Prism.highlightAll(false);
+                this.highlightContent(false);
             },
             err => this.handleError);
     }
@@ -119,5 +121,15 @@ export class MarkdownComponent implements OnInit {
      */
     private trimLeft(line: string) {
         return line.replace(/^\s+|\s+$/g, '');
+    }
+
+    /**
+     * Use Prism to highlight code snippets only on the browser
+     * @param {string} async param passed directly to Prism.highlightAll
+     */
+    private highlightContent(async: boolean): void {
+      if (isPlatformBrowser(this.platformId)) {
+        Prism.highlightAll(async);
+      }
     }
 }


### PR DESCRIPTION
Hi @dimpu! I apparently never got the notification from your answer on the linked issue, so sorry for that! 

This PR implements the naive solution to allow for universal rendering.

closes #69 